### PR TITLE
Add labelling actions

### DIFF
--- a/.github/workflows/add-issue-to-project.yml
+++ b/.github/workflows/add-issue-to-project.yml
@@ -1,0 +1,47 @@
+# Specify the ORGANIZATION and the PROJECT_NUMBER.
+# The token TRIAGE_TOKEN is a personal token with scopes "repo", "write:org" and "read:org", and added to the organization secrets.
+# Note that your repo needs to be in the scope of the TRIAGE_TOKEN : you can add your repo in the settings of the organization secrets.
+name: Add issue to project
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  track_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get project data
+        env:
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+          ORGANIZATION: tchapgouv
+          PROJECT_NUMBER: 8
+        run: |
+          gh api graphql -f query='
+            query($org: String!, $number: Int!) {
+              organization(login: $org){
+                projectNext(number: $number) {
+                  id
+                  fields(first:20) {
+                    nodes {
+                      id
+                      name
+                      settings
+                    }
+                  }
+                }
+              }
+            }' -f org=$ORGANIZATION -F number=$PROJECT_NUMBER > project_data.json
+          echo 'PROJECT_ID='$(jq '.data.organization.projectNext.id' project_data.json) >> $GITHUB_ENV
+      - name: Add issue to project
+        env:
+          GITHUB_TOKEN: ${{ secrets.TRIAGE_TOKEN }}
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+        run: |
+          item_id="$( gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID --jq '.data.addProjectNextItem.projectNextItem.id')"

--- a/.github/workflows/label-new-issues.yml
+++ b/.github/workflows/label-new-issues.yml
@@ -1,0 +1,20 @@
+# Change the label name in the job if needed.
+# If the label is already present, this job runs successfully and does nothing.
+name: Label new issues
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  label_issue:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['identite']
+            })


### PR DESCRIPTION
Resolve #37 
- Auto add to "all issues" board
- Auto add label 'identite' when creating the issue

Pour mémoire, c'est le board ici: https://github.com/orgs/tchapgouv/projects/8/views/22
Testable une fois mergé uniquement, mais déjà utilisé ailleurs, donc il devrait pas y avoir de problèmes