### PR TITLE
feat: avoid email spamming

### DIFF
--- a/src/main/java/org/beta/tchap/identite/authenticator/OtpLoginAuthenticator.java
+++ b/src/main/java/org/beta/tchap/identite/authenticator/OtpLoginAuthenticator.java
@@ -93,7 +93,7 @@ public class OtpLoginAuthenticator extends AbstractUsernameFormAuthenticator
         context.challenge(otpForm(context,null));
     }
 
-    private Response otpForm(AuthenticationFlowContext context, String info){
+    static Response otpForm(AuthenticationFlowContext context, String info){
         String userEmail = context.getAuthenticationSession().getAuthNote(AUTH_NOTE_USER_EMAIL);
 
         /* if userEmail is not set in the authentication session, fails */
@@ -110,7 +110,7 @@ public class OtpLoginAuthenticator extends AbstractUsernameFormAuthenticator
         return form.createForm(FTL_ENTER_CODE);
     }
 
-    private Response otpFormError(AuthenticationFlowContext context, String error){
+    static Response otpFormError(AuthenticationFlowContext context, String error){
         String userEmail = context.getAuthenticationSession().getAuthNote(AUTH_NOTE_USER_EMAIL);
 
         /* if userEmail is not set in the authentication session, fails */

--- a/src/main/java/org/beta/tchap/identite/authenticator/TchapAuthenticator.java
+++ b/src/main/java/org/beta/tchap/identite/authenticator/TchapAuthenticator.java
@@ -15,6 +15,11 @@ import org.keycloak.sessions.AuthenticationSessionModel;
 
 import javax.ws.rs.core.Response;
 
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+
 import static org.beta.tchap.identite.authenticator.OtpLoginAuthenticator.*;
 
 public class TchapAuthenticator implements Authenticator {
@@ -22,6 +27,10 @@ public class TchapAuthenticator implements Authenticator {
     private final SecureCode secureCode;
     private final EmailSender emailSender;
     private static final String FTL_UNAUTHORIZED_USER       = "unauthorized-user.ftl";
+    private static final Integer MAX_LOGIN_HINTS_OCCURENCE_FOR_ONE_BROWSER = 10;
+    private static final Integer SEND_CODE_COOLDOWN_IN_MINUTES = 1;
+    private static final String SEND_CODE_TIMESTAMP = "send-code-timestamp";
+
 
     private static final Logger LOG = Logger.getLogger(TchapAuthenticator.class);
 
@@ -35,42 +44,118 @@ public class TchapAuthenticator implements Authenticator {
         AuthenticationSessionModel session  = context.getAuthenticationSession();
         String loginHint = session.getClientNote(OIDCLoginProtocol.LOGIN_HINT_PARAM);
 
-        if(loginHint ==null){
+        if(loginHint == null){
             context.failure(AuthenticationFlowError.GENERIC_AUTHENTICATION_ERROR,
                     Response.status(400).build(), "request is malformed", "request is malformed" );
             return;
         }
-        if(LOG.isDebugEnabled()){
-            LOG.debugf("Authenticate login : %s", LoggingUtilsFactory.getInstance().logOrHash(loginHint));
+
+        if(tooManyLoginHints(context)){
+            LOG.warnf("Authenticate login : %s, parent session has used too many different loginHints",
+                    LoggingUtilsFactory.getInstance().logOrHash(loginHint));
+            context.challenge(otpForm(context,"Nous avons détecté de multiples tentatives de login différentes depuis ce poste, veuillez contacter un administrateur audioConf pour continuer"));
+
+            return;
         }
+
+        if(!canSendNewCode(context)){
+            if(LOG.isDebugEnabled()){LOG.debugf("Authenticate login : %s, a previous code has been sent. Should wait for cool down delay before sending a new one",
+                    LoggingUtilsFactory.getInstance().logOrHash(loginHint));}
+
+            context.challenge(otpForm(context,
+                    String.format("Un code vous a déjà été envoyé, veuillez attendre %s minute avant de demander un nouveau code", SEND_CODE_COOLDOWN_IN_MINUTES)));
+            return;
+        }
+
+        if(LOG.isDebugEnabled()){LOG.debugf("Authenticate login : %s, AuthenticationSession.TabId : %s, ParentSession.Id %s",
+                    LoggingUtilsFactory.getInstance().logOrHash(loginHint),
+                    context.getAuthenticationSession().getTabId(),
+                    context.getAuthenticationSession().getParentSession().getId());
+        }
+
+        //set loginHint in keycloak authentication session (attached to browser>tab via cookie)
         context.getAuthenticationSession().setAuthNote(AUTH_NOTE_USER_EMAIL, loginHint);
         UserModel user = getUser(context);
 
         if (user == null) {
-            showUnautorhizedUser(context);
+            showUnauthorizedUser(context);
             return;
         }
 
         //user has been found
-        generateAndSendCode(context);
-        context.success();
+        if(generateAndSendCode(context)){
+            //code has been sent
+            context.success();
+        }
     }
 
-    private void showUnautorhizedUser(AuthenticationFlowContext context){
-        String message = "Cet email ne correspond pas à une agence de l'État. Si vous appartenez à un service de l'État mais votre email n'est pas reconnu par AudioConf, contactez-nous pour que nous le rajoutions!";
-           /* context.failure(AuthenticationFlowError.UNKNOWN_USER, Response.status(401).build(),
-                    "user was not found in Tchap", message );
-            */
+    /**
+     * Check if a new code can be sent. A cool down delay must be respected.
+     * @param context keycloak auth context
+     * @return true/false
+     */
+    boolean canSendNewCode(AuthenticationFlowContext context) {
+        long timestamp = getLastCodeTimestamp(context);
+        if(LOG.isDebugEnabled()){ LOG.debugf("Last timestamp found in authentication sessions note %s", timestamp);}
+
+        return timestamp == 0 || (Instant.now().toEpochMilli() - timestamp) > SEND_CODE_COOLDOWN_IN_MINUTES * 60 * 1000;
+    }
+
+    /* set timestamp in auth session */
+    private void setCodeTimestamp(AuthenticationFlowContext context){
+        context.getAuthenticationSession().setAuthNote(SEND_CODE_TIMESTAMP, String.valueOf(Instant.now().toEpochMilli()));
+    }
+
+    /**
+     * check that occurences login hints have been used from authentication sessions from this
+     * browser is not superior than MAX_LOGIN_HINTS_OCCURENCE_FOR_ONE_BROWSER
+     * @param context keycloak auth context
+     * @return number of different login hints
+     */
+    private boolean tooManyLoginHints(AuthenticationFlowContext context){
+        Set<String> loginHints = new HashSet<>();
+        for(AuthenticationSessionModel session : context.getAuthenticationSession().getParentSession().getAuthenticationSessions().values()){
+            String loginHint = session.getAuthNote(AUTH_NOTE_USER_EMAIL);
+            if(loginHint!=null){
+                loginHints.add(loginHint);
+            }
+        }
+        return loginHints.size() > MAX_LOGIN_HINTS_OCCURENCE_FOR_ONE_BROWSER;
+    }
+
+    /**
+     * Return last code timestamp from authentication sessions from this browser
+     * @param context keycloak auth context
+     * @return timestamp or 0 if none
+     */
+    private long getLastCodeTimestamp(AuthenticationFlowContext context){
+        Set<Long> timestamps = new HashSet<>();
+        for(AuthenticationSessionModel session :
+                context.getAuthenticationSession().getParentSession().getAuthenticationSessions().values()){
+            String timestampString = session.getAuthNote(SEND_CODE_TIMESTAMP);
+            if(timestampString!=null){
+                timestamps.add(Long.parseLong(timestampString));
+            }
+        }
+        if(timestamps.isEmpty()){
+            return 0;
+        }
+        return Collections.max(timestamps);
+    }
+
+
+    private void showUnauthorizedUser(AuthenticationFlowContext context){
         context.failure(AuthenticationFlowError.GENERIC_AUTHENTICATION_ERROR,  context.form()
                 .createForm(FTL_UNAUTHORIZED_USER)
                 , "unknown user", "unknow user");
-
-
-
     }
 
-    private void generateAndSendCode(AuthenticationFlowContext context)
-    {
+    /**
+     * Send a OTP to the user by email
+     * @param context keycloak auth context
+     * @return true is email has been sent
+     */
+    private boolean generateAndSendCode(AuthenticationFlowContext context){
         String code = secureCode.generateCode(6);
         context.getAuthenticationSession().setAuthNote(AUTH_NOTE_OTP, code);
         context.getAuthenticationSession().setAuthNote(AUTH_NOTE_TIMESTAMP,
@@ -80,17 +165,21 @@ public class TchapAuthenticator implements Authenticator {
         if(LOG.isDebugEnabled()){
             LOG.debugf("Sending OTP : %s", LoggingUtilsFactory.getInstance().logOrHide(friendlyCode));
         }
-        emailSender.sendEmail(context.getSession(), context.getRealm(),
-                              getUser(context), friendlyCode);
+        if(!emailSender.sendEmail(context.getSession(), context.getRealm(),
+                              getUser(context), friendlyCode)){
+            //error while sending email
+            otpFormError(context, "Impossible de vous envoyer l'email avec le code de connection, veuillez réessayer");
+            return false;
+        }
 
-
+        setCodeTimestamp(context);
+        return true;
         /*
          * TODO: SEND CODE TO TCHAP ALSO
          */
     }
 
-    private UserModel getUser(AuthenticationFlowContext context)
-    {
+    private UserModel getUser(AuthenticationFlowContext context){
         return context.getSession().users().getUserByEmail(context.getRealm(),
                 context.getAuthenticationSession().getAuthNote(AUTH_NOTE_USER_EMAIL));
     }


### PR DESCRIPTION
Avoid email spamming with a cooldown : Users can not request new code within less than 1 minute
Avoid loginHint spamming : Users can not request code for more than 10 different loginHints from the same browser

+ previous rules : 
- code are valid 20 minutes
- code must be input after at least 2 seconds after generation


