### PR TITLE
feat: externalize error message to resources

### DIFF
--- a/theme/tchap-otp-login/login/enter-code.ftl
+++ b/theme/tchap-otp-login/login/enter-code.ftl
@@ -1,9 +1,10 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=social.displayInfo pageTitle="${client.name}" clientName="${client.name}" clientDescription="${client.description}" clientUrl="${client.baseUrl}" ; section>
+<@layout.registrationLayout pageTitle="${client.name}"  ; section>
     <#if section = "title">
         ${msg("loginTitle",(realm.displayName!''))}
     <#elseif section = "header">
     <#elseif section = "form">
+
         <h2>Rentrez votre code secret</h2>
         <form id="kc-form-login" class="${properties.kcFormClass!}" onsubmit="login.disabled = true; return true;"
               action="${url.loginAction}" method="post">
@@ -23,8 +24,9 @@
                                                                                                         ${client.name}.
                         </label>
 
+
                     <input tabindex="1" id="codeInput" class="${properties.kcInputClass!} code-input" name="codeInput" type="text"
-                           autofocus minlength="6" maxlength="8" required/>
+                           autofocus minlength="6" maxlength="8" required ${(message?has_content && message.type = 'error' && errorType = 'error.email.not.sent')?then("disabled","")}/>
             </div>
 
             <div class="${properties.kcFormGroupClass!}">

--- a/theme/tchap-otp-login/login/error.ftl
+++ b/theme/tchap-otp-login/login/error.ftl
@@ -1,7 +1,11 @@
 <#import "template.ftl" as layout>
+<!-- error page miss the client variable sometimes-->
+<#assign clientUrl = (client??)?then(client.baseUrl,'')>
+
 <@layout.registrationLayout displayMessage=false; section>
     <#if section = "header">
     <#elseif section = "form">
+        <h2>Authentification</h2>
 
                 <div class="fr-callout fr-alert fr-alert--error">
 
@@ -11,7 +15,7 @@
 
 
                 </div>
-                    <a type="submit" class="fr-btn" href="${client.baseUrl}">Réessayer</a>
+                    <a type="submit" class="fr-btn" href="${clientUrl}">Réessayer</a>
 
 
     </#if>

--- a/theme/tchap-otp-login/login/error.ftl
+++ b/theme/tchap-otp-login/login/error.ftl
@@ -1,0 +1,18 @@
+<#import "template.ftl" as layout>
+<@layout.registrationLayout displayMessage=false; section>
+    <#if section = "header">
+    <#elseif section = "form">
+
+                <div class="fr-callout fr-alert fr-alert--error">
+
+                    <p class="fr-callout__text">${kcSanitize(message.summary)?no_esc}</p>
+
+                    <a class="fr-btn fr-btn--primary" title="Nous contacter" href="https://audioconf.numerique.gouv.fr/contact">Nous contacter</a>
+
+
+                </div>
+                    <a type="submit" class="fr-btn" href="${client.baseUrl}">Réessayer</a>
+
+
+    </#if>
+</@layout.registrationLayout>

--- a/theme/tchap-otp-login/login/messages/messages_fr.properties
+++ b/theme/tchap-otp-login/login/messages/messages_fr.properties
@@ -5,8 +5,8 @@ internalServerError=Aie, nous sommes dans l''incapacité de traiter votre demande
 
 #tchap error messages
 error.email.not.sent=Aie, nous n''avons pas r\u00e9ussi à envoyer le mail avec le code, pouvez-vous r\u00e9essayer?
-error.invalid.code=Le code n'' est pas valide. V\u00e9rifiez votre saisie ou demandez un nouveau code.
-error.invalid.code.in.session=Le code n' est pas valide. Veuillez demander un nouveau code.
+error.invalid.code=Le code n''est pas valide. V\u00e9rifiez votre saisie ou demandez un nouveau code.
+error.invalid.code.in.session=Le code n''est pas valide. Veuillez demander un nouveau code.
 
 
 info.input.code=Veuillez renseigner un code

--- a/theme/tchap-otp-login/login/messages/messages_fr.properties
+++ b/theme/tchap-otp-login/login/messages/messages_fr.properties
@@ -1,13 +1,13 @@
 #keycloak error messages
-identityProviderUnexpectedErrorMessage=Aie, nous sommes dans l''incapacit\u00e9 de traiter votre demande d'authentification pour le moment, veuillez r\u00e9essayer ult\u00e9rieurement.
-unexpectedErrorHandlingRequestMessage=Aie, nous sommes dans l''incapacit\u00e9 de traiter votre demande d''authentification pour le moment, veuillez r\u00e9essayer ult\u00e9rieurement.
-internalServerError=Aie, nous sommes dans l''incapacit\u00e9 de traiter votre demande d''authentification pour le moment, veuillez r\u00e9essayer ult\u00e9rieurement.
+identityProviderUnexpectedErrorMessage=Nous ne pouvons malheureusement pas traiter votre demande d'authentification pour le moment. Merci de r\u00e9essayer ult\u00e9rieurement.
+unexpectedErrorHandlingRequestMessage=Nous ne pouvons malheureusement pas traiter votre demande d'authentification pour le moment. Merci de r\u00e9essayer ult\u00e9rieurement.
+internalServerError=Aie, nous sommes dans l''incapacit\u00e9 de traiter votre demande d''authentification pour le moment. Merci de r\u00e9essayer ult\u00e9rieurement.
 
 #tchap error messages
-error.email.not.sent=Aie, nous n''avons pas r\u00e9ussi \u00e0 envoyer le mail avec le code, pouvez-vous r\u00e9essayer?
-error.invalid.code=Le code n''est pas valide. V\u00e9rifiez votre saisie ou demandez un nouveau code.
+error.email.not.sent=Nous n''avons pas r\u00e9ussi \u00e0 envoyer le mail avec le code. Merci de r\u00e9essayer ult\u00e9rieurement.
+error.invalid.code=Le code n''est pas valide. Veuillez v\u00e9rifiez le code saisi ou demandez un nouveau code.
 error.invalid.code.in.session=Le code n''est pas valide. Veuillez demander un nouveau code.
-error.unknown.domain=Cet email ne correspond pas \u00e0 une agence de l''\u00c9tat. Si vous appartenez \u00e0 un service de l''\u00c9tat mais votre email n'est pas reconnu par notre service d''authentification, contactez-nous pour que nous le rajoutions!
+error.unknown.domain=Cette adresse mail n''est pas reconnu par notre service d''authentification. Si vous appartenez \u00e0 un service de l''\u00c9tat et votre adresse mail n'est pas reconnue par notre service d''authentification, contactez-nous.
 
 info.input.code=Veuillez renseigner un code
-info.code.already.sent.wait=Un code vous a d\u00e9j\u00e0 \u00e9t\u00e9 envoy\u00e9, veuillez attendre {0} minute avant de demander un nouveau code.
+info.code.already.sent.wait=Un code vous a d\u00e9j\u00e0 \u00e9t\u00e9 envoy\u00e9. Merci d''attendre {0} minutes avant de demander un nouveau code.

--- a/theme/tchap-otp-login/login/messages/messages_fr.properties
+++ b/theme/tchap-otp-login/login/messages/messages_fr.properties
@@ -1,13 +1,13 @@
 #keycloak error messages
-identityProviderUnexpectedErrorMessage=Aie, nous sommes dans l''incapacité de traiter votre demande d'authentification pour le moment, veuillez r\u00e9essayer ult\u00e9rieurement.
-unexpectedErrorHandlingRequestMessage=Aie, nous sommes dans l''incapacité de traiter votre demande d''authentification pour le moment, veuillez r\u00e9essayer ult\u00e9rieurement.
-internalServerError=Aie, nous sommes dans l''incapacité de traiter votre demande d''authentification pour le moment, veuillez r\u00e9essayer ult\u00e9rieurement.
+identityProviderUnexpectedErrorMessage=Aie, nous sommes dans l''incapacit\u00e9 de traiter votre demande d'authentification pour le moment, veuillez r\u00e9essayer ult\u00e9rieurement.
+unexpectedErrorHandlingRequestMessage=Aie, nous sommes dans l''incapacit\u00e9 de traiter votre demande d''authentification pour le moment, veuillez r\u00e9essayer ult\u00e9rieurement.
+internalServerError=Aie, nous sommes dans l''incapacit\u00e9 de traiter votre demande d''authentification pour le moment, veuillez r\u00e9essayer ult\u00e9rieurement.
 
 #tchap error messages
-error.email.not.sent=Aie, nous n''avons pas r\u00e9ussi à envoyer le mail avec le code, pouvez-vous r\u00e9essayer?
+error.email.not.sent=Aie, nous n''avons pas r\u00e9ussi \u00e0 envoyer le mail avec le code, pouvez-vous r\u00e9essayer?
 error.invalid.code=Le code n''est pas valide. V\u00e9rifiez votre saisie ou demandez un nouveau code.
 error.invalid.code.in.session=Le code n''est pas valide. Veuillez demander un nouveau code.
-
+error.unknown.domain=Cet email ne correspond pas \u00e0 une agence de l''\u00c9tat. Si vous appartenez \u00e0 un service de l''\u00c9tat mais votre email n'est pas reconnu par notre service d''authentification, contactez-nous pour que nous le rajoutions!
 
 info.input.code=Veuillez renseigner un code
 info.code.already.sent.wait=Un code vous a d\u00e9j\u00e0 \u00e9t\u00e9 envoy\u00e9, veuillez attendre {0} minute avant de demander un nouveau code.

--- a/theme/tchap-otp-login/login/messages/messages_fr.properties
+++ b/theme/tchap-otp-login/login/messages/messages_fr.properties
@@ -1,7 +1,7 @@
 #keycloak error messages
 identityProviderUnexpectedErrorMessage=Nous ne pouvons malheureusement pas traiter votre demande d'authentification pour le moment. Merci de r\u00e9essayer ult\u00e9rieurement.
 unexpectedErrorHandlingRequestMessage=Nous ne pouvons malheureusement pas traiter votre demande d'authentification pour le moment. Merci de r\u00e9essayer ult\u00e9rieurement.
-internalServerError=Aie, nous sommes dans l''incapacit\u00e9 de traiter votre demande d''authentification pour le moment. Merci de r\u00e9essayer ult\u00e9rieurement.
+internalServerError=Nous ne pouvons malheureusement pas traiter votre demande d'authentification pour le moment. Merci de r\u00e9essayer ult\u00e9rieurement.
 
 #tchap error messages
 error.email.not.sent=Nous n''avons pas r\u00e9ussi \u00e0 envoyer le mail avec le code. Merci de r\u00e9essayer ult\u00e9rieurement.

--- a/theme/tchap-otp-login/login/messages/messages_fr.properties
+++ b/theme/tchap-otp-login/login/messages/messages_fr.properties
@@ -1,5 +1,13 @@
-loginTitle=Log in to {0}
-loginTitleHtml={0}
-enterCode=Renseignez le code que vous avez recu sur Tchap et à votre adresse mail 
-enterCodeNote=In case of false input the code turns invalid. We will send you a new one.
-doLogIn=Log in
+#keycloak error messages
+identityProviderUnexpectedErrorMessage=Aie, nous sommes dans l''incapacité de traiter votre demande d'authentification pour le moment, veuillez r\u00e9essayer ult\u00e9rieurement.
+unexpectedErrorHandlingRequestMessage=Aie, nous sommes dans l''incapacité de traiter votre demande d''authentification pour le moment, veuillez r\u00e9essayer ult\u00e9rieurement.
+internalServerError=Aie, nous sommes dans l''incapacité de traiter votre demande d''authentification pour le moment, veuillez r\u00e9essayer ult\u00e9rieurement.
+
+#tchap error messages
+error.email.not.sent=Aie, nous n''avons pas r\u00e9ussi à envoyer le mail avec le code, pouvez-vous r\u00e9essayer?
+error.invalid.code=Le code n'' est pas valide. V\u00e9rifiez votre saisie ou demandez un nouveau code.
+error.invalid.code.in.session=Le code n' est pas valide. Veuillez demander un nouveau code.
+
+
+info.input.code=Veuillez renseigner un code
+info.code.already.sent.wait=Un code vous a d\u00e9j\u00e0 \u00e9t\u00e9 envoy\u00e9, veuillez attendre {0} minute avant de demander un nouveau code.

--- a/theme/tchap-otp-login/login/template.ftl
+++ b/theme/tchap-otp-login/login/template.ftl
@@ -1,6 +1,12 @@
-<#macro registrationLayout bodyClass="" displayInfo=false displayMessage=true displayRequiredFields=false displayWide=false showAnotherWayIfPresent=true clientUrl="" pageTitle="" clientName="" clientDescription="">
+<#macro registrationLayout bodyClass="" displayMessage=false displayRequiredFields=false displayWide=false showAnotherWayIfPresent=true  pageTitle="">
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
+
+
+<#assign clientName = (client??)?then(client.name,'Authentification')>
+<#assign clientDescription = (client??)?then(client.description,'Authentifier les utilisateurs simplement')>
+<#assign clientUrl = (client??)?then(client.baseUrl,'')>
+
 
 <head>
     <meta charset="utf-8">
@@ -12,7 +18,7 @@
             <meta name="${meta?split('==')[0]}" content="${meta?split('==')[1]}"/>
         </#list>
     </#if>
-    <title>${pageTitle}</title>
+    <title>${clientName}</title>
     <link rel="icon" href="${url.resourcesPath}/img/favicon.ico" />
     <link rel="icon" type="image/png" sizes="16x16" href="${url.resourcesPath}/img/favicon-16x16.png">
     <link rel="icon" type="image/png" sizes="32x32" href="${url.resourcesPath}/img/favicon-32x32.png">
@@ -60,7 +66,7 @@
                     <div class="fr-header__service">
                         <a href="${clientUrl}" title="Accueil - ${clientName}">
                             <p class="fr-header__service-title">
-                                ${pageTitle}
+                                ${clientName}
                             </p>
                         <p class="fr-header__service-tagline">${clientDescription}</p>
                         </a>
@@ -186,13 +192,7 @@
               </form>
               </#if>
 
-              <#if displayInfo>
-                  <div id="kc-info">
-                      <div id="kc-info-wrapper">
-                          <#nested "info">
-                      </div>
-                  </div>
-              </#if>
+
             </div>
           </div>
           </div>

--- a/theme/tchap-otp-login/login/unauthorized-user.ftl
+++ b/theme/tchap-otp-login/login/unauthorized-user.ftl
@@ -1,18 +1,21 @@
 <#import "template.ftl" as layout>
 <@layout.registrationLayout ; section>
+<#assign clientUrl = (client??)?then(client.baseUrl,'')>
+<#assign clientName = (client??)?then(client.name,'')>
+
     <#if section = "title">
         ${msg("loginTitle",(realm.displayName!''))}
     <#elseif section = "header">
     <#elseif section = "form">
-        <h2>Réserver une conférence téléphonique</h2>
+        <h2>Authentification</h2>
         <div class="fr-callout fr-alert fr-alert--warning">
 
-            <p class="fr-callout__text">Cet email ne correspond pas à une agence de l'État. Si vous appartenez à un service de l'État mais votre email n'est pas reconnu par AudioConf, contactez-nous pour que nous le rajoutions!</p>
+            <p class="fr-callout__text">${msg("error.unknown.domain","clientName")} </p>
 
             <a class="fr-btn fr-btn--primary" title="Nous contacter" href="https://audioconf.numerique.gouv.fr/contact">Nous contacter</a>
 
 
         </div>
-        <a type="submit" class="fr-btn" href="${client.baseUrl}">Réserver une autre conférence</a>
+        <a type="submit" class="fr-btn" href="${clientUrl}">Réessayer</a>
     </#if>
 </@layout.registrationLayout>

--- a/theme/tchap-otp-login/login/unauthorized-user.ftl
+++ b/theme/tchap-otp-login/login/unauthorized-user.ftl
@@ -1,5 +1,5 @@
 <#import "template.ftl" as layout>
-<@layout.registrationLayout displayInfo=social.displayInfo pageTitle="${client.name}" clientUrl="${client.baseUrl}" ; section>
+<@layout.registrationLayout ; section>
     <#if section = "title">
         ${msg("loginTitle",(realm.displayName!''))}
     <#elseif section = "header">


### PR DESCRIPTION
Nouveaux messages d'erreurs : (les '' c'est normal)

**erreur générique** : "Aie, nous sommes dans l''incapacité de traiter votre demande d'authentification pour le moment, veuillez réessayer ultérieurement."

#tchap error messages
**lorsque l'email ne part pas** : "Aie, nous n''avons pas réussi à envoyer le mail avec le code, pouvez-vous réessayer?"
**lorsque le code est invalide** : "Le code n''est pas valide. Vérifiez votre saisie ou demandez un nouveau code."
lorsque l'utilisateur redemande un code trop rapidement: "Un code vous a déjà été envoyé, veuillez attendre {0} minute avant de demander un nouveau code."
**lorsque le domaine n'est pas reconnu** : Cet email ne correspond pas à une agence de l'État. Si vous appartenez à un service de l'État mais votre email n'est pas reconnu par AudioConf, contactez-nous pour que nous le rajoutions!