### PR TITLE
remove placeholder in code input form

### DIFF
--- a/theme/tchap-otp-login/login/enter-code.ftl
+++ b/theme/tchap-otp-login/login/enter-code.ftl
@@ -27,7 +27,7 @@
                 <div class="fr-col-1 hideMobile">
                     <img src="${url.resourcesPath}/img/enter-code-arrow.png" class="fr-responsive-img fr-p-1w"/>
                 </div>
-                <div class="fr-col-12 fr-col-md-6 fr-p-4w fr-mt-5w">
+                <div class="fr-col-12 fr-col-md-6 fr-p-1w fr-p-md-4w fr-mt-md-5w">
                     <div class="fr-grid-row">
                         <span class="fr-hint-text">exemple de code: abc-def</span>
                           <input tabindex="1" id="codeInput" class="fr-input codeInput fr-m-auto" name="codeInput" type="text" autofocus minlength="6" maxlength="8" required ${(message?has_content && message.type = 'error' && errorType = 'error.email.not.sent')?then("disabled","")}/>

--- a/theme/tchap-otp-login/login/enter-code.ftl
+++ b/theme/tchap-otp-login/login/enter-code.ftl
@@ -29,7 +29,8 @@
                 </div>
                 <div class="fr-col-12 fr-col-md-6 fr-p-4w fr-mt-5w">
                     <div class="fr-grid-row">
-                          <input tabindex="1" id="codeInput" class="fr-input codeInput fr-m-auto" name="codeInput" type="text" placeholder="abc-def" autofocus minlength="6" maxlength="8" required ${(message?has_content && message.type = 'error' && errorType = 'error.email.not.sent')?then("disabled","")}/>
+                        <span class="fr-hint-text">exemple de code: abc-def</span>
+                          <input tabindex="1" id="codeInput" class="fr-input codeInput fr-m-auto" name="codeInput" type="text" autofocus minlength="6" maxlength="8" required ${(message?has_content && message.type = 'error' && errorType = 'error.email.not.sent')?then("disabled","")}/>
                     </div>
                     <div class="fr-grid-row fr-my-3w">
                         <input tabindex="4" class="fr-btn fr-m-auto" name="login" id="login" type="submit" value="Confirmer"/>

--- a/theme/tchap-otp-login/login/resources/css/enter-code.css
+++ b/theme/tchap-otp-login/login/resources/css/enter-code.css
@@ -1,15 +1,16 @@
 #codeInput {
-    /* width: 200px !important; */
     max-height: none !important;
     text-align: center!important;
     line-height: 3rem!important;
-    font-size: 3rem!important;
+    font-size: 2rem!important;
     font-style: normal;
 }
 
-#codeInput::placeholder {
-    font-weight: lighter;
-  }
+@media screen and (min-width: 768px) {
+    #codeInput {
+        font-size: 3rem!important;
+    }
+}
 
 .hideMobile {
     display: none;
@@ -21,3 +22,4 @@
         display: block;
     }
 }
+

--- a/theme/tchap-otp-login/login/template.ftl
+++ b/theme/tchap-otp-login/login/template.ftl
@@ -172,7 +172,7 @@
               <#-- App-initiated actions should not see warning messages about the need to complete the action -->
               <#-- during login.                                                                               -->
               <#if displayMessage && message?has_content && (message.type != 'warning' || !isAppInitiatedAction??)>
-                  <div class="fr-alert fr-alert--${message.type} fr-alert--sm fr-mb-3w">
+                  <div class="fr-alert fr-alert--${message.type} fr-alert--sm fr-mb-1w fr-mb-md-2w">
                       <#if message.type = 'success'><span class="${properties.kcFeedbackSuccessIcon!}"></span></#if>
                       <#if message.type = 'warning'><span class="${properties.kcFeedbackWarningIcon!}"></span></#if>
                       <#if message.type = 'error'><span class="${properties.kcFeedbackErrorIcon!}"></span></#if>

--- a/theme/tchap-otp-login/login/template.ftl
+++ b/theme/tchap-otp-login/login/template.ftl
@@ -57,11 +57,11 @@
                                 <br>Française
                             </p>
                         </div>
-                        <div class="fr-header__navbar">
+                        <#--  <div class="fr-header__navbar">
                             <button class="fr-btn--menu fr-btn" data-fr-opened="false" aria-controls="modal-menu" aria-haspopup="menu" title="Menu">
                                 Menu
                             </button>
-                        </div>
+                        </div>  -->
                     </div>
                     <div class="fr-header__service">
                         <a href="${clientUrl}" title="Accueil - ${clientName}">


### PR DESCRIPTION
Le placeholder a été remplacé par un texte d'aide selon les recommandations du [dsfr](https://gouvfr.atlassian.net/wiki/spaces/DB/pages/217088099/Champs+de+saisie+-+Input)

<img width="1010" alt="Capture d’écran 2022-07-06 à 11 28 35" src="https://user-images.githubusercontent.com/4077729/177518774-fb88d0fa-3e6b-41cd-9b84-43c9b2e2749c.png">


Mobile : 

<img width="381" alt="Capture d’écran 2022-07-06 à 11 49 47" src="https://user-images.githubusercontent.com/4077729/177523150-e09af41a-05d8-4f17-9cb0-773ec5afc9e9.png">

