### PR TITLE
Mise à jour du readme pour faciliter l'installation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,19 +1,19 @@
 # Docker compose
 POSTGRES_DB=keycloak
 POSTGRES_USER=user
-POSTGRES_PASSWORD=
+POSTGRES_PASSWORD=password
 PORT=8080
 
 # keycloak build
 KEYCLOAK_ADMIN=admin
-KEYCLOAK_ADMIN_PASSWORD=
+KEYCLOAK_ADMIN_PASSWORD=password
 
 # keycloak run envs
 KC_DB=postgres
 KC_DB_SCHEMA=public
 KC_DB_URL=jdbc:postgresql://postgres:5432/keycloak
 KC_DB_USERNAME=user
-KC_DB_PASSWORD=
+KC_DB_PASSWORD=password
 KC_PROXY=edge
 KC_HTTP_PORT=8080
 KC_CACHE=local
@@ -44,6 +44,7 @@ TCHAP_CODE_TIMEOUT_IN_MINUTES=60
 #TCHAP_HOME_REDIRECT_URL=https://audioconf.numerique.gouv.fr/questions-frequentes#qui-peut-avoir-acces
 TCHAP_HOME_REDIRECT_URL=/admin
 
+# service account for Tchap Identity created on Tchap Server side
 TCHAP_BOT_ACCOUNT_EMAIL=
 TCHAP_BOT_PASSWORD=""
 

--- a/README.md
+++ b/README.md
@@ -58,21 +58,22 @@ L'erreur suivante peut se produire lors de l'exécution de la commande `mvn clea
 
 > DefaultHomeServerStrategyTest.should_get_healthy_client_success_with_one_home_server:16 » Retryable PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target executing GET https://matrix.i.tchap.gouv.fr/_matrix/identity/api/v1/info?address=%40beta.gouv.fr&medium=email
 
-sudo keytool -import -alias tchap -keystore "/Library/Java/JavaVirtualMachines/jdk-19.jdk/Contents/Home/lib/security/cacerts" -file www.beta-sir.tchap.gouv.fr.cer
 
 Il faut ajouter à Java le certificat de l'URL incriminée.
 
-Importer le certificat avec Chrome (Firefox et Safari n'ont pas de bouton "exporter")
+D'abord, [ouvrez l'URL avec Google Chrome](https://matrix.i.tchap.gouv.fr/_matrix/identity/api/v1/info?address=%40beta.gouv.fr&medium=email) et exportez le certificat (Firefox et Safari n'ont pas de bouton "exporter"). Vous obtenez un fichier `.cer` dont vous aurez besoin plus loin.
 
-Pour savoir quelle JDK utilise Maven :
+Lancez la commande suivante pour savoir quelle JDK utilise Maven :
+```
 mvn -version
+```
+Il vous donne un "runtime" qui se termine par `Contents/Home`. Reprenez ce chemin runtime et ajoutez-y `/lib/security/cacerts`.
 
-Il vous donne un "runtime" qui se termine par `Contents/Home`
-Reprenez ce chemin runtime et ajoutez `/lib/security/cacerts`
+Lancez la commande suivante pour ajouter le certificat à Java (remplacez "votre runtime java" par celui obtenu à l'exemple précédent). Dans l'exemple, le fichier certificat s'appelle `www.beta-sir.tchap.gouv.fr.cer` :
 
-Lancez la commande :
-
-keytool -import -alias tchap -keystore "/opt/homebrew/Cellar/openjdk/19.0.1/libexec/openjdk.jdk/Contents/Home/lib/security/cacerts" -file www.beta-sir.tchap.gouv.fr.cer -storepass changeit
+```
+keytool -import -alias tchap -keystore "<votre runtime java>/lib/security/cacerts" -file www.beta-sir.tchap.gouv.fr.cer -storepass changeit
+```
 
 ### Error response from daemon
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ cp .env.samble .env
 
 to specify a version run :
 `mvn clean install -Drevision=X.Y.Z`
-For local development, the jar is copied to /dev/providers
+
+For local development, the jar is copied to `/dev/providers`
 
 3. launch containers
 
@@ -46,3 +47,47 @@ https://github.com/tchapgouv/oidc-client-example
 
 1. To format the code, execute the following command : `mvn spotless:apply`
 2. You can view the diff with : `git diff `
+
+## Troubleshooting
+
+### SunCertPathBuilderException lors du build
+
+L'erreur suivante peut se produire lors de l'exécution de la commande `mvn clean package` :
+
+> DefaultHomeServerStrategyTest.should_get_healthy_client_success_with_one_home_server:16 » Retryable PKIX path building failed: sun.security.provider.certpath.SunCertPathBuilderException: unable to find valid certification path to requested target executing GET https://matrix.i.tchap.gouv.fr/_matrix/identity/api/v1/info?address=%40beta.gouv.fr&medium=email
+
+sudo keytool -import -alias tchap -keystore "/Library/Java/JavaVirtualMachines/jdk-19.jdk/Contents/Home/lib/security/cacerts" -file www.beta-sir.tchap.gouv.fr.cer
+
+Il faut ajouter à Java le certificat de l'URL incriminée.
+
+Importer le certificat avec Chrome (Firefox et Safari n'ont pas de bouton "exporter")
+
+Pour savoir quelle JDK utilise Maven :
+mvn -version
+
+Il vous donne un "runtime" qui se termine par `Contents/Home`
+Reprenez ce chemin runtime et ajoutez `/lib/security/cacerts`
+
+Lancez la commande :
+
+keytool -import -alias tchap -keystore "/opt/homebrew/Cellar/openjdk/19.0.1/libexec/openjdk.jdk/Contents/Home/lib/security/cacerts" -file www.beta-sir.tchap.gouv.fr.cer -storepass changeit
+
+### Error response from daemon
+
+Cette erreur peut se produire lors du lancement de `docker compose up`:
+
+> Error response from daemon: Head "https://ghcr.io/v2/tchapgouv/keycloak-buildpack/manifests/master": unauthorized
+
+On essaie d'accéder à un package sur la plateforme de github, mais pour cela il faut s'authentifier.
+
+Tout d'abord, [créez un token d'accès "classique" à Github](https://docs.github.com/fr/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#cr%C3%A9ation-dun-personal-access-token-classic). Donnez-lui simplement la permission `read:packages`.
+
+Puis lancez la commande suivante pour vous connecter :
+
+```
+docker login ghcr.io --username <votre-login-github>
+```
+
+Lorsqu'un mot de passe vous est demandé, entrez le token qui a été généré ci-dessus.
+
+Ensuite, le `docker compose up` fonctionne.

--- a/README.md
+++ b/README.md
@@ -94,3 +94,27 @@ docker login ghcr.io --username <votre-login-github>
 Lorsqu'un mot de passe vous est demandé, entrez le token qui a été généré ci-dessus.
 
 Ensuite, le `docker compose up` fonctionne.
+
+### duplicate key value violates unique constraint "uk_cli_scope"
+
+Dans les logs docker compose, vous pouvez voir "tchap-identite-keycloak-1 exited with code 1" ce qui signifie qu'il y a eu un problème.
+
+    tchap-identite-keycloak-1  | 2023-01-25 09:49:58,552 ERROR [org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler] (main) ERROR: could not execute statement
+    tchap-identite-keycloak-1  | 2023-01-25 09:49:58,552 ERROR [org.keycloak.quarkus.runtime.cli.ExecutionExceptionHandler] (main) ERROR: ERROR: duplicate key value violates unique constraint "uk_cli_scope"
+    tchap-identite-keycloak-1  |   Detail: Key (realm_id, name)=(c82a6531-6dd5-424e-ac9e-844ebd5e8f91, role_list) already exists.
+
+Cela peut être dû à un problème lors de l'initialisation du conteneur. Une solution est de supprimer tous les conteneurs du projet, puis le volume de la base de données.
+
+Pour lister les conteneurs docker :
+
+```
+docker ps --all
+```
+
+Pour les supprimer : `docker rm xxx yyy zzzz` où xxx, yyy et zzz sont les "container ID".
+
+Pour supprimer le volume de la base de données :
+
+```
+docker volume rm tchap-identite_db_volume
+```

--- a/README.md
+++ b/README.md
@@ -6,41 +6,43 @@ Le projet Authentification otp publie un service d'authentification qui se base 
 Realm uptime can be found here : https://updown.io/fta9
 
 ## Stack Technology
+
 - maven : 3.8.2
 - keycloak : 18.0
 - quarkus : 2.7.5
 - java : 11
 
-## Run the local environment with docker containers
+## Exécution du projet en local avec des conteneurs docker
 
-1. copy env.sample -> env, fill in passwords with (any value you want..)
+1. Créez le fichier `.env` à partir du fichier .env.sample
 
 ```
-cp .env.samble .env
+cp .env.sample .env
 ````
 
-2. build extension with maven goal. A jar is produced with the custom providers and the custom view.
+2. Construisez l'extension à l'aide de Maven. Un fichier `.jar` est créé dans `/dev/providers`.
 
-`mvn clean package`
+```
+mvn clean package
+```
 
-to specify a version run :
+Pour préciser la version lors du run :
 `mvn clean install -Drevision=X.Y.Z`
 
-For local development, the jar is copied to `/dev/providers`
 
-3. launch containers
+3. Lancez les conteneurs docker
 
-`docker compose up`
+```
+docker compose up
+```
 
-4. Connect to
-- keycloak admin http://localhost:8080 with admin/password
-- in realm Tchap-identite, go to Clients>tchap-identite-client-sample>credentials> "Regenerate Secret"
-- copy this secret in your open id client (see -4-)
-- email client : http://localhost:1080
+4. L'admin keycloak est disponible à l'adresse http://localhost:8080 (admin/password), le client email est dispo à http://localhost:1080
 
-5. install a openId client sample
+5. Utilisation d'un client openID : 
 
-https://github.com/tchapgouv/oidc-client-example
+- installez un client d'exemple openID (p. ex https://github.com/tchapgouv/oidc-client-example)
+- dans l'admin keycloak, depuis le realm Tchap-identite, suivez Clients -> tchap-identite-client-sample -> credentials -> "Regenerate Secret"
+- copiez ce secret dans votre client openID
 
 
 ## Code formatting

--- a/README.md
+++ b/README.md
@@ -14,19 +14,12 @@ Realm uptime can be found here : https://updown.io/fta9
 ## Run the local environment with docker containers
 
 1. copy env.sample -> env, fill in passwords with (any value you want..)
-- POSTGRES_PASSWORD=password
-- KEYCLOAK_ADMIN_PASSWORD=password
-- KC_DB_PASSWORD=password
-- TCHAP_BOT_ACCOUNT_EMAIL=service account for Tchap Identity created on Tchap Server side
-- TCHAP_BOT_PASSWORD=password for the service account
-- TCHAP_HOME_SERVER_LIST=list of home servers that tchap-identity can connect to
-- TCHAP_SKIP_CERTIFICATE_VALIDATION=false
-- TCHAP_UNAUTHORIZED_HOME_SERVER_LIST=list of unauthorized home servers -- use to check if a user is valid
-- TCHAP_OTP_MAIL_DELAY_IN_MINUTES= (optionnal) delay to wait to send another otp to users. default 0
-- TCHAP_CODE_TIMEOUT_IN_MINUTES= (optionnal) validity of a otp code. default 60
-- TCHAP_LOG_SENSITIVE_DATA = (optionnal) log sensitive data like username. default false
-- TCHAP_HOME_REDIRECT_URL=url to redirect the user when it hits the welcome page (/admin by default)
-1. build extension with maven goal. A jar is produced with the custom providers and the custom view.
+
+```
+cp .env.samble .env
+````
+
+2. build extension with maven goal. A jar is produced with the custom providers and the custom view.
 
 `mvn clean package`
 


### PR DESCRIPTION
J'ai essayé d'installer l'appli et j'ai beaucoup souffert.

Voici quelques propositions pour faciliter l'installation : 

- changement du `.env.sample` avec des _sensible defaults_, qu'on ait juste à le copier sans devoir chercher les lignes où ajouter "password=password".
- remaniement des instructions du readme pour les passer en français, supprimer les infos inutiles (car déjà dans le .env par exemple) et les mettre dans un ordre plus logique.
- ajout d'une section "troubleshooting" avec les erreurs que j'ai rencontrées et des propositions de solution.